### PR TITLE
Refactor timing system to keep verse speed consistent

### DIFF
--- a/LyricAnimator/Configuration/SongConfiguration.cs
+++ b/LyricAnimator/Configuration/SongConfiguration.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 using Newtonsoft.Json;
 
 namespace LyricAnimator.Configuration
@@ -9,7 +8,8 @@ namespace LyricAnimator.Configuration
         public string SongTitle { get; set; }
         public string AudioFilePath { get; set; }
         public string OutputFilename { get; set; }
-        public List<Lyric> Lyrics { get; set; }
+        public string LyricsFilePath { get; set; }
+        public string Duration { get; set; }
 
         public static SongConfiguration LoadFromFile(string filePath)
         {


### PR DESCRIPTION
* Move lyrics configuration to a separate text file to make it easier to transcribe lyrics.
* Include timings/verse labels in the plaintext lyrics file.
* Refactor timing system to ensure verses maintain consistent spacing and move at the same speed. Speed will be adjusted dynamically as needed to keep lyrics at a consistent reading level.